### PR TITLE
ci: 上传插件测试脚本

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,3 +66,15 @@ jobs:
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+
+  github-relase:
+    name: GitHub release
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ github.event_name == 'release' && github.event.action == 'published' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Upload Files
+        run: gh release upload --clobber ${{ env.TAG_NAME }} plugin_test.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ci:
   autofix_commit_msg: "style: auto fix by pre-commit hooks"
   autofix_prs: true
-  autoupdate_branch: dev
+  autoupdate_branch: main
   autoupdate_schedule: weekly
   autoupdate_commit_msg: "chore: auto update by pre-commit hooks"
 repos:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
       - name: Test Plugin
         id: plugin-test
         run: |
-          curl -sSL https://raw.githubusercontent.com/nonebot/nonebot2-publish-bot/main/plugin_test.py -o plugin_test.py
+          curl -sSL https://github.com/nonebot/nonebot2-publish-bot/releases/latest/download/plugin_test.py -o plugin_test.py
           python plugin_test.py
   publish_bot:
     runs-on: ubuntu-latest
@@ -74,7 +74,7 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
       - name: NoneBot2 Publish Bot
-        uses: docker://ghcr.io/nonebot/nonebot2-publish-bot:main
+        uses: docker://ghcr.io/nonebot/nonebot2-publish-bot:latest
         with:
           token: ${{ secrets.GH_TOKEN }}
           config: >


### PR DESCRIPTION
发布新版本后上传测试脚本至 assets。以后只保留 main 分支，删除 dev 分支。