### PR TITLE
ci: 修复上传文件出错

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,3 +81,5 @@ jobs:
 
       - name: Upload Files
         run: gh release upload --clobber ${{ env.TAG_NAME }} plugin_test.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set Tag Name
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
       - name: Upload Files
         run: gh release upload --clobber ${{ env.TAG_NAME }} plugin_test.py


### PR DESCRIPTION
还需要设置 TAG_NAME 和 GITHUB_TOKEN。